### PR TITLE
Added build & deploy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ IFC OpenBIM format.
 
 ![Screenshot](assets/img/screenshot.png)
 
+## See it in action
+
+See a [live demo](https://flexdemo.xbim-dev.net/) of the Flex Webkit to see what you can do with Flex!
+
 ## Getting Started
 
 This is an [Angular 9](https://angular.io/docs) front-end web project, demonstrating how to use the

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'windows-latest'
 
 steps:
 - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,15 +19,13 @@ steps:
       cd flex-demo
       npm install -g @angular/cli
       npm install
-      ng build --prod
-    displayName: 'npm install and build'
-  - task: Npm@1
-    inputs:
-      command: 'custom'
-      workingDir: 'flex-demo'
-      customCommand: 'run ng build --prod'
-    displayName: 'npm build --prod'
+    displayName: 'npm install'
 
+  - script: |
+      cd flex-demo
+      ng build --prod
+    displayName: 'npm build'
+  
 
   - task: ArchiveFiles@2
     displayName: 'Archive $(Build.SourcesDirectory)/flex-demo/dist/flex-demo'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,15 +20,14 @@ steps:
     displayName: 'Install NG'
 
   - script: |
-    cd flex-demo
-    npm install
-  displayName: 'npm install'
+      cd flex-demo
+      npm install
+    displayName: 'npm install'
 
   - script: |
       cd flex-demo
       ng build --prod
     displayName: 'npm build'
-  
 
   - task: ArchiveFiles@2
     displayName: 'Archive $(Build.SourcesDirectory)/flex-demo/dist/flex-demo'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,10 +16,13 @@ steps:
     displayName: 'Install Node.js'
 
   - script: |
-      cd flex-demo
       npm install -g @angular/cli
-      npm install
-    displayName: 'npm install'
+    displayName: 'Install NG'
+
+  - script: |
+    cd flex-demo
+    npm install
+  displayName: 'npm install'
 
   - script: |
       cd flex-demo

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pool:
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '10.x'
+      versionSpec: '12.x'
     displayName: 'Install Node.js'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,34 +4,34 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- master
+  - master
 
 pool:
   vmImage: 'windows-latest'
 
 steps:
-- task: NodeTool@0
-  inputs:
-    versionSpec: '10.x'
-  displayName: 'Install Node.js'
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '10.x'
+    displayName: 'Install Node.js'
 
-- script: |
-    cd flex-demo
-    npm install -g @angular/cli
-    npm install
-    ng build --prod
-  displayName: 'npm install and build'
+  - script: |
+      cd flex-demo
+      npm install -g @angular/cli
+      npm install
+      ng build --prod
+    displayName: 'npm install and build'
 
-- task: ArchiveFiles@2
-  displayName: 'Archive $(Build.SourcesDirectory)/dist/apps/flex-demo'
-  inputs:
-    rootFolderOrFile: '$(Build.SourcesDirectory)/dist/apps/flex-demo'
-    includeRootFolder: false
-    archiveType: 'zip'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/flex-demo$(Build.BuildId).zip'
-    replaceExistingArchive: true
+  - task: ArchiveFiles@2
+    displayName: 'Archive $(Build.SourcesDirectory)/flex-demo/dist/apps/flex-demo'
+    inputs:
+      rootFolderOrFile: '$(Build.SourcesDirectory)/flex-demo/dist/apps/flex-demo'
+      includeRootFolder: false
+      archiveType: 'zip'
+      archiveFile: '$(Build.ArtifactStagingDirectory)/flex-demo$(Build.BuildId).zip'
+      replaceExistingArchive: true
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: app'
-  inputs:
-    ArtifactName: app
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: app'
+    inputs:
+      ArtifactName: app

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,13 @@ steps:
       npm install
       ng build --prod
     displayName: 'npm install and build'
+  - task: Npm@1
+    inputs:
+      command: 'custom'
+      workingDir: 'flex-demo'
+      customCommand: 'run ng build --prod'
+    displayName: 'npm build --prod'
+
 
   - task: ArchiveFiles@2
     displayName: 'Archive $(Build.SourcesDirectory)/flex-demo/dist/flex-demo'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,9 +23,9 @@ steps:
     displayName: 'npm install and build'
 
   - task: ArchiveFiles@2
-    displayName: 'Archive $(Build.SourcesDirectory)/flex-demo/dist/apps/flex-demo'
+    displayName: 'Archive $(Build.SourcesDirectory)/flex-demo/dist/flex-demo'
     inputs:
-      rootFolderOrFile: '$(Build.SourcesDirectory)/flex-demo/dist/apps/flex-demo'
+      rootFolderOrFile: '$(Build.SourcesDirectory)/flex-demo/dist/flex-demo'
       includeRootFolder: false
       archiveType: 'zip'
       archiveFile: '$(Build.ArtifactStagingDirectory)/flex-demo$(Build.BuildId).zip'

--- a/flex-demo/angular.json
+++ b/flex-demo/angular.json
@@ -28,6 +28,7 @@
               "src/assets",
               "src/silent-refresh.html",
               "src/config.json",
+              "src/config.aspx",
               "src/web.config"
             ],
             "styles": ["src/styles.scss"],

--- a/flex-demo/src/app/session/session.component.html
+++ b/flex-demo/src/app/session/session.component.html
@@ -40,7 +40,7 @@
       </tr>
       <tr>
         <td>Client Id:</td>
-        <td><b>{{env.clientId}})</b></td>
+        <td><b>{{config.clientId}}</b></td>
       </tr>
       <tr>
         <td>Scopes:</td>

--- a/flex-demo/src/config.aspx
+++ b/flex-demo/src/config.aspx
@@ -7,13 +7,13 @@
    public void Page_Load(object sender, EventArgs e)
     {
         var environment = new {
-            baseUrl = Environment.GetEnvironmentVariable("BaseUrl"),
-            clientId = Environment.GetEnvironmentVariable("ClientId"),
+            baseUrl = Environment.GetEnvironmentVariable("BaseUrl") ?? "https://localhost:4202",
+            clientId = Environment.GetEnvironmentVariable("ClientId") ?? "853519a5-e1b1-4be8-93b3-ac21a4180294",
             endpoints = new {
-                identityBaseUrl = Environment.GetEnvironmentVariable("Endpoints::IdentityEndpoint"),
-                flexApiBaseUrl = Environment.GetEnvironmentVariable("Endpoints::FlexApiEndpoint"),
-                hubApiBaseUrl = Environment.GetEnvironmentVariable("Endpoints::HubApiEndpoint"),
-                commsApiBaseUrl = Environment.GetEnvironmentVariable("Endpoints::CommsApiEndpoint"),
+                identityBaseUrl = Environment.GetEnvironmentVariable("Endpoints::IdentityEndpoint") ?? "https://id.xbim-dev.net",
+                flexApiBaseUrl = Environment.GetEnvironmentVariable("Endpoints::FlexApiEndpoint") ?? "https://api.xbim-dev.net",
+                hubApiBaseUrl = Environment.GetEnvironmentVariable("Endpoints::HubApiEndpoint") ?? "https://hub.xbim-dev.net",
+                commsApiBaseUrl = Environment.GetEnvironmentVariable("Endpoints::CommsApiEndpoint") ?? "https://comms-api.xbim-dev.net",
                 flexAppBaseUrl = Environment.GetEnvironmentVariable("Endpoints::FlexUIEndpoint"),
                 commsAppBaseUrl = Environment.GetEnvironmentVariable("Endpoints::CommsUIEndpoint"),
                 publicHomePage = Environment.GetEnvironmentVariable("Endpoints::PublicHomeEndpoint") ?? "https://www.xbim.net"

--- a/flex-demo/src/web.config
+++ b/flex-demo/src/web.config
@@ -1,4 +1,6 @@
 <configuration>
+<!-- Note this is only employed on IIS, Azure etc. It demonstrates how you might host the Angular app in a production server on .NET 
+-->
     <system.webServer>
         <staticContent>
             <mimeMap fileExtension=".woff" mimeType="application/font-woff" />


### PR DESCRIPTION
Supports deploying to flex-demo.xbim-dev.net so the Flex Demo can be tried out without installation

Added some basic support for running in Azure/IIS using web.config re-writes and dynamic config.json

Note that running on any other URL than localhost:4202 will require a redirectURL be registered in Flex. Normally you'll be issued with your client ID on which you can set the redirect url for signin/out.
